### PR TITLE
feat(auth): hide navbar on auth-related pages

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,4 +1,4 @@
 
 
-<app-navbar></app-navbar> 
+<app-navbar *ngIf="!hideNavbar"></app-navbar>
 <router-outlet></router-outlet>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,16 +1,20 @@
 import { Component } from '@angular/core';
-import { RouterOutlet } from '@angular/router';
+import { CommonModule } from '@angular/common';
+import { RouterOutlet ,Router} from '@angular/router';
 import { NavbarComponent } from './components/navbar-components/navbar/navbar.component';
 
 
 @Component({
   selector: 'app-root',
   standalone: true,
-  imports: [RouterOutlet  NavbarComponent],
+  imports: [RouterOutlet ,NavbarComponent,CommonModule],
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.css']
 
 })
 export class AppComponent {
-  title = 'bookStore-client';
-}
+  constructor(public router: Router) {}
+
+  get hideNavbar(): boolean {
+    return ['/login', '/register','/otp-verification','/otp-complete','/password-reset','/password-reset-confirm'].includes(this.router.url);
+  }}

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -11,12 +11,12 @@ import { PasswordResetConfirmComponent } from './pages/auth/password-reset-confi
 import { OtpCompleteComponent } from './pages/auth/otp-complete/otp-complete.component';
 import { ProductDetailsComponent } from './pages/product-details/product-details.component';
 
-import { BooksPageComponent } from './pages/books-page/books-page.component';
+// import { BooksPageComponent } from './pages/books-page/books-page.component';
 import { HomePageComponent } from './home-page/home-page.component';
 export const routes: Routes = [
   { path: '', component: HomePageComponent },
   { path: 'wishlist', component: WishlistComponent },
-  { path: 'shop', component: BooksPageComponent },
+  // { path: 'shop', component: BooksPageComponent },
   { path: 'checkout', component: CheckoutComponent, title: 'Payment Form' },
   { path: 'login', component: LoginComponent },
   { path: 'register', component: RegistrationComponent },


### PR DESCRIPTION
Add conditional rendering of navbar component to hide it on login, register, and password reset pages. This improves user experience by removing unnecessary navigation elements during authentication flows.

- Add hideNavbar getter in AppComponent to check current route
- Update app.component.html to conditionally render navbar
- Remove unused BooksPageComponent import from routes