### PR TITLE
refactor(auth): remove facebook login button from login page

### DIFF
--- a/src/app/pages/auth/login/login.component.html
+++ b/src/app/pages/auth/login/login.component.html
@@ -87,19 +87,7 @@
         </div>
 
         <div class="social-login">
-          <button
-            type="button"
-
-            class="social-btn facebook-btn"
-            (click)="signInWithFacebook()"
-          >
-            <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
-              <path
-                d="M13.397 20.997v-8.196h2.765l.411-3.209h-3.176V7.548c0-.926.258-1.56 1.587-1.56h1.684V3.127A22.336 22.336 0 0 0 14.201 3c-2.444 0-4.122 1.492-4.122 4.231v2.355H7.332v3.209h2.753v8.202h3.312z"
-              />
-            </svg>
-            Facebook
-          </button>
+         
 
           <button id="google-signin-button"
             type="button"


### PR DESCRIPTION
The Facebook login functionality was removed as it's no longer supported by our authentication service. This simplifies the login page and removes unused code.